### PR TITLE
Dev

### DIFF
--- a/client/src/components/Graph.js
+++ b/client/src/components/Graph.js
@@ -5,10 +5,6 @@ class Graph extends Component{
     constructor(props){
         super(props);
 
-        //console.log("Datalength1: " + this.props.inputArr.data.length);
-        console.log("Graph props:")
-        console.log(this.props);
-
         this.state = ({
             graphData:{
                 labels: this.props.inputArr.labels,
@@ -29,6 +25,11 @@ class Graph extends Component{
     // Call this when this component receives new props
     componentWillReceiveProps(props){
         // Calling setState causes this component to re-render with the new data its received
+
+        console.log("Updated Graph props:")
+        console.log(props);
+
+
         this.setState({
             graphData:{
                 labels: props.inputArr.labels,

--- a/client/src/components/MainContainer/MainContainer.js
+++ b/client/src/components/MainContainer/MainContainer.js
@@ -7,6 +7,12 @@ import Header from "../Header/Header";
 import ControlPanel from "../ControlPanel/ControlPanel";
 import * as d3 from 'd3';
 import data from '../../csv_files/13013356000.csv'; // Hard coded in...
+import annotation_p from '../../csv_files/Annotattion/P.csv';
+import annotation_q from '../../csv_files/Annotattion/Q.csv';
+import annotation_r from '../../csv_files/Annotattion/R.csv';
+import annotation_s from '../../csv_files/Annotattion/S.csv';
+import annotation_t from '../../csv_files/Annotattion/T.csv';
+
 
 export default class MainContainer extends React.Component {
 	constructor(props){
@@ -26,7 +32,12 @@ export default class MainContainer extends React.Component {
             v3: '',
             v4: '',
             v5: '',
-            v6: ''
+            v6: '',
+            p: '',
+            q: '',
+            r: '',
+            s: '',
+            t: ''
         }
     }
 
@@ -44,7 +55,11 @@ export default class MainContainer extends React.Component {
         let lead_v4 = [];
         let lead_v5 = [];
         let lead_v6 = [];
-
+        let annotation_p = [];
+        let annotation_q = [];
+        let annotation_r = [];
+        let annotation_s = [];
+        let annotation_t = [];
         let labels = [];
 
         //Parse the CSV into an array of objects where each object represents a row
@@ -107,7 +122,9 @@ export default class MainContainer extends React.Component {
                 v5: lead_v5,
                 v6: lead_v6
             })   
-		})
+        })
+        
+        //Handle Parsing the annotation data 
     }
 	
 	render() {

--- a/client/src/components/MainContainer/MainContainer.js
+++ b/client/src/components/MainContainer/MainContainer.js
@@ -41,6 +41,27 @@ export default class MainContainer extends React.Component {
         }
     }
 
+    //Function to generalize the loading of annotation files
+    //Since the logic for all 5 is the exact same
+    //Receives a CSV file and an array for output
+    //Processes the CSV file into the specified array
+    //Returns nothing
+    parseAnnotationCsv(inputCsv, outputArr)
+    {
+        var parsed_p = d3.csv(inputCsv).then(function(data)
+        {
+            return data;
+        })
+
+        parsed_p.then(function(data)
+        {
+            for(var i = 0; i < data.columns.length; i++)
+            {
+                outputArr.push(+data.columns[i]);
+            }
+        })
+    }
+
     componentWillMount(){
         //Define arrays
         var lead_i = [];
@@ -123,22 +144,21 @@ export default class MainContainer extends React.Component {
                 v6: lead_v6
             })   
         })
-        
-        //Handle Parsing the annotation data 
-        var parsed_p = d3.csv(csv_p).then(function(data)
-        {
-            return data;
-        })
 
-        parsed_p.then(function(data)
-        {
-            for(var i = 0; i < data.columns.length; i++)
-            {
-                annotation_p.push(+data.columns[i]);
-                //console.log(data.columns[i]);
-            }
+        //Parse and store all annotation data in the appropriate arrays
+        this.parseAnnotationCsv(csv_p, annotation_p);
+        this.parseAnnotationCsv(csv_q, annotation_q);
+        this.parseAnnotationCsv(csv_r, annotation_r);
+        this.parseAnnotationCsv(csv_s, annotation_s);
+        this.parseAnnotationCsv(csv_t, annotation_t);
 
-            console.log(annotation_p);
+        //Update the state again now that annotation data is parsed
+        this.setState({
+                p: annotation_p,
+                q: annotation_q,
+                r: annotation_r,
+                s: annotation_s,
+                t: annotation_t
         })
     }
 	
@@ -152,20 +172,22 @@ export default class MainContainer extends React.Component {
 				</Grid>
 
 				<Grid>
-					<GridItem inputArr={{data: this.state.i, title: "Lead I", labels: this.state.labels}}/>
-					<GridItem inputArr={{data: this.state.avl, title: "Lead aVL", labels: this.state.labels}}/>
-					<GridItem inputArr={{data: this.state.ii, title: "Lead II", labels: this.state.labels}}/>
-					<GridItem inputArr={{data: this.state.iii, title: "Lead III", labels: this.state.labels}}/>
-					<GridItem inputArr={{data: this.state.avf, title: "Lead aVF", labels: this.state.labels}}/>
-					<GridItem inputArr={{data: this.state.avr, title: "Lead aVR", labels: this.state.labels}}/>
-					<GridItem inputArr={{data: this.state.v1, title: "Lead V1", labels: this.state.labels}}/>
-					<GridItem inputArr={{data: this.state.v2, title: "Lead V2", labels: this.state.labels}}/>
-					<GridItem inputArr={{data: this.state.v3, title: "Lead V3", labels: this.state.labels}}/>
-					<GridItem inputArr={{data: this.state.v4, title: "Lead V4", labels: this.state.labels}}/>
-					<GridItem inputArr={{data: this.state.v5, title: "Lead V5", labels: this.state.labels}}/>
-					<GridItem inputArr={{data: this.state.v6, title: "Lead V6", labels: this.state.labels}}/>
+					<GridItem inputArr={{data: this.state.i, title: "Lead I", labels: this.state.labels, p: this.p, q: this.q, r: this.r, s: this.s, t: this.t}}/>
+					<GridItem inputArr={{data: this.state.avl, title: "Lead aVL", labels: this.state.labels, p: this.p, q: this.q, r: this.r, s: this.s, t: this.t}}/>
+					<GridItem inputArr={{data: this.state.ii, title: "Lead II", labels: this.state.labels, p: this.p, q: this.q, r: this.r, s: this.s, t: this.t}}/>
+					<GridItem inputArr={{data: this.state.iii, title: "Lead III", labels: this.state.labels, p: this.p, q: this.q, r: this.r, s: this.s, t: this.t}}/>
+					<GridItem inputArr={{data: this.state.avf, title: "Lead aVF", labels: this.state.labels, p: this.p, q: this.q, r: this.r, s: this.s, t: this.t}}/>
+					<GridItem inputArr={{data: this.state.avr, title: "Lead aVR", labels: this.state.labels, p: this.p, q: this.q, r: this.r, s: this.s, t: this.t}}/>
+					<GridItem inputArr={{data: this.state.v1, title: "Lead V1", labels: this.state.labels, p: this.p, q: this.q, r: this.r, s: this.s, t: this.t}}/>
+					<GridItem inputArr={{data: this.state.v2, title: "Lead V2", labels: this.state.labels, p: this.p, q: this.q, r: this.r, s: this.s, t: this.t}}/>
+					<GridItem inputArr={{data: this.state.v3, title: "Lead V3", labels: this.state.labels, p: this.p, q: this.q, r: this.r, s: this.s, t: this.t}}/>
+					<GridItem inputArr={{data: this.state.v4, title: "Lead V4", labels: this.state.labels, p: this.p, q: this.q, r: this.r, s: this.s, t: this.t}}/>
+					<GridItem inputArr={{data: this.state.v5, title: "Lead V5", labels: this.state.labels, p: this.p, q: this.q, r: this.r, s: this.s, t: this.t}}/>
+					<GridItem inputArr={{data: this.state.v6, title: "Lead V6", labels: this.state.labels, p: this.p, q: this.q, r: this.r, s: this.s, t: this.t}}/>
 				</Grid>
 			</div>
 		);
 	}
 }
+
+

--- a/client/src/components/MainContainer/MainContainer.js
+++ b/client/src/components/MainContainer/MainContainer.js
@@ -172,18 +172,18 @@ export default class MainContainer extends React.Component {
 				</Grid>
 
 				<Grid>
-					<GridItem inputArr={{data: this.state.i, title: "Lead I", labels: this.state.labels, p: this.p, q: this.q, r: this.r, s: this.s, t: this.t}}/>
-					<GridItem inputArr={{data: this.state.avl, title: "Lead aVL", labels: this.state.labels, p: this.p, q: this.q, r: this.r, s: this.s, t: this.t}}/>
-					<GridItem inputArr={{data: this.state.ii, title: "Lead II", labels: this.state.labels, p: this.p, q: this.q, r: this.r, s: this.s, t: this.t}}/>
-					<GridItem inputArr={{data: this.state.iii, title: "Lead III", labels: this.state.labels, p: this.p, q: this.q, r: this.r, s: this.s, t: this.t}}/>
-					<GridItem inputArr={{data: this.state.avf, title: "Lead aVF", labels: this.state.labels, p: this.p, q: this.q, r: this.r, s: this.s, t: this.t}}/>
-					<GridItem inputArr={{data: this.state.avr, title: "Lead aVR", labels: this.state.labels, p: this.p, q: this.q, r: this.r, s: this.s, t: this.t}}/>
-					<GridItem inputArr={{data: this.state.v1, title: "Lead V1", labels: this.state.labels, p: this.p, q: this.q, r: this.r, s: this.s, t: this.t}}/>
-					<GridItem inputArr={{data: this.state.v2, title: "Lead V2", labels: this.state.labels, p: this.p, q: this.q, r: this.r, s: this.s, t: this.t}}/>
-					<GridItem inputArr={{data: this.state.v3, title: "Lead V3", labels: this.state.labels, p: this.p, q: this.q, r: this.r, s: this.s, t: this.t}}/>
-					<GridItem inputArr={{data: this.state.v4, title: "Lead V4", labels: this.state.labels, p: this.p, q: this.q, r: this.r, s: this.s, t: this.t}}/>
-					<GridItem inputArr={{data: this.state.v5, title: "Lead V5", labels: this.state.labels, p: this.p, q: this.q, r: this.r, s: this.s, t: this.t}}/>
-					<GridItem inputArr={{data: this.state.v6, title: "Lead V6", labels: this.state.labels, p: this.p, q: this.q, r: this.r, s: this.s, t: this.t}}/>
+					<GridItem inputArr={{data: this.state.i, title: "Lead I", labels: this.state.labels, p: this.state.p, q: this.state.q, r: this.state.r, s: this.state.s, t: this.state.t}}/>
+					<GridItem inputArr={{data: this.state.avl, title: "Lead aVL", labels: this.state.labels, p: this.state.p, q: this.state.q, r: this.state.r, s: this.state.s, t: this.state.t}}/>
+					<GridItem inputArr={{data: this.state.ii, title: "Lead II", labels: this.state.labels, p: this.state.p, q: this.state.q, r: this.state.r, s: this.state.s, t: this.state.t}}/>
+					<GridItem inputArr={{data: this.state.iii, title: "Lead III", labels: this.state.labels, p: this.state.p, q: this.state.q, r: this.state.r, s: this.state.s, t: this.state.t}}/>
+					<GridItem inputArr={{data: this.state.avf, title: "Lead aVF", labels: this.state.labels, p: this.state.p, q: this.state.q, r: this.state.r, s: this.state.s, t: this.state.t}}/>
+					<GridItem inputArr={{data: this.state.avr, title: "Lead aVR", labels: this.state.labels, p: this.state.p, q: this.state.q, r: this.state.r, s: this.state.s, t: this.state.t}}/>
+					<GridItem inputArr={{data: this.state.v1, title: "Lead V1", labels: this.state.labels, p: this.state.p, q: this.state.q, r: this.state.r, s: this.state.s, t: this.state.t}}/>
+					<GridItem inputArr={{data: this.state.v2, title: "Lead V2", labels: this.state.labels, p: this.state.p, q: this.state.q, r: this.state.r, s: this.state.s, t: this.state.t}}/>
+					<GridItem inputArr={{data: this.state.v3, title: "Lead V3", labels: this.state.labels, p: this.state.p, q: this.state.q, r: this.state.r, s: this.state.s, t: this.state.t}}/>
+					<GridItem inputArr={{data: this.state.v4, title: "Lead V4", labels: this.state.labels, p: this.state.p, q: this.state.q, r: this.state.r, s: this.state.s, t: this.state.t}}/>
+					<GridItem inputArr={{data: this.state.v5, title: "Lead V5", labels: this.state.labels, p: this.state.p, q: this.state.q, r: this.state.r, s: this.state.s, t: this.state.t}}/>
+					<GridItem inputArr={{data: this.state.v6, title: "Lead V6", labels: this.state.labels, p: this.state.p, q: this.state.q, r: this.state.r, s: this.state.s, t: this.state.t}}/>
 				</Grid>
 			</div>
 		);

--- a/client/src/components/MainContainer/MainContainer.js
+++ b/client/src/components/MainContainer/MainContainer.js
@@ -7,11 +7,11 @@ import Header from "../Header/Header";
 import ControlPanel from "../ControlPanel/ControlPanel";
 import * as d3 from 'd3';
 import data from '../../csv_files/13013356000.csv'; // Hard coded in...
-import annotation_p from '../../csv_files/Annotattion/P.csv';
-import annotation_q from '../../csv_files/Annotattion/Q.csv';
-import annotation_r from '../../csv_files/Annotattion/R.csv';
-import annotation_s from '../../csv_files/Annotattion/S.csv';
-import annotation_t from '../../csv_files/Annotattion/T.csv';
+import csv_p from '../../csv_files/Annotattion/P.csv';
+import csv_q from '../../csv_files/Annotattion/Q.csv';
+import csv_r from '../../csv_files/Annotattion/R.csv';
+import csv_s from '../../csv_files/Annotattion/S.csv';
+import csv_t from '../../csv_files/Annotattion/T.csv';
 
 
 export default class MainContainer extends React.Component {
@@ -125,6 +125,21 @@ export default class MainContainer extends React.Component {
         })
         
         //Handle Parsing the annotation data 
+        var parsed_p = d3.csv(csv_p).then(function(data)
+        {
+            return data;
+        })
+
+        parsed_p.then(function(data)
+        {
+            for(var i = 0; i < data.columns.length; i++)
+            {
+                annotation_p.push(+data.columns[i]);
+                //console.log(data.columns[i]);
+            }
+
+            console.log(annotation_p);
+        })
     }
 	
 	render() {


### PR DESCRIPTION
This pull request implements parsing of annotation files. Logic was packaged into a function so we can reuse it to parse annotation files for all 12 individual leads when we transition to production. Currently the function is being leveraged to parse in all 5 of the given annotation files we have. That data is then being sent as a props to every single graph. With this implementation it will be trivial to make the necessary modifications to support different sets of annotation files for each of the 12 leads. 